### PR TITLE
Tests for links as hashes

### DIFF
--- a/test/ipld-tests.js
+++ b/test/ipld-tests.js
@@ -125,75 +125,73 @@ module.exports = (repo) => {
       })
     })
 
-    describe('across linked objects', () => {
-      describe('where links are multihashes', () => {
-        const aliceName = 'Alice'
-        const aliceAbout = {
-          age: 22
-        }
-        const bob = {
-          name: 'Bob'
-        }
-        const alice = {
-          name: {
-            '@link': ipld.multihash(aliceName)
-          },
-          about: {
-            '@link': ipld.multihash(ipld.marshal(aliceAbout))
-          },
-          friends: [{
-            '@link': ipld.multihash(ipld.marshal(bob))
-          }]
-        }
-        const mh = ipld.multihash(ipld.marshal(alice))
+    describe('links are hashes', () => {
+      const aliceName = 'Alice'
+      const aliceAbout = {
+        age: 22
+      }
+      const bob = {
+        name: 'Bob'
+      }
+      const alice = {
+        name: {
+          '@link': ipld.multihash(aliceName)
+        },
+        about: {
+          '@link': ipld.multihash(ipld.marshal(aliceAbout))
+        },
+        friends: [{
+          '@link': ipld.multihash(ipld.marshal(bob))
+        }]
+      }
+      const mh = ipld.multihash(ipld.marshal(alice))
 
-        before((done) => {
-          async.series([
-            (cb) => ipldService.add(aliceName, cb),
-            (cb) => ipldService.add(aliceAbout, cb),
-            (cb) => ipldService.add(alice, cb),
-            (cb) => ipldService.add(bob, cb)
-          ], done)
+      before((done) => {
+        async.series([
+          (cb) => ipldService.add(aliceName, cb),
+          (cb) => ipldService.add(aliceAbout, cb),
+          (cb) => ipldService.add(alice, cb),
+          (cb) => ipldService.add(bob, cb)
+        ], done)
+      })
+
+      it('resolves link to string', (done) => {
+        resolve(ipldService, `${mh}/name`, (err, res) => {
+          expect(err).to.not.exist
+          expect(res).to.be.eql(aliceName)
+          done()
         })
+      })
 
-        it('resolves link to string', (done) => {
-          resolve(ipldService, `${mh}/name`, (err, res) => {
-            expect(err).to.not.exist
-            expect(res).to.be.eql(aliceName)
-            done()
-          })
+      it('resolves link to object', (done) => {
+        resolve(ipldService, `${mh}/about`, (err, res) => {
+          expect(err).to.not.exist
+          expect(res).to.be.eql(aliceAbout)
+          done()
         })
+      })
 
-        it('resolves link to object', (done) => {
-          resolve(ipldService, `${mh}/about`, (err, res) => {
-            expect(err).to.not.exist
-            expect(res).to.be.eql(aliceAbout)
-            done()
-          })
+      it('resolves link to property in a different object', (done) => {
+        resolve(ipldService, `${mh}/about/age`, (err, res) => {
+          expect(err).to.not.exist
+          expect(res).to.be.eql(aliceAbout.age)
+          done()
         })
+      })
 
-        it('resolves link to property in a different object', (done) => {
-          resolve(ipldService, `${mh}/about/age`, (err, res) => {
-            expect(err).to.not.exist
-            expect(res).to.be.eql(aliceAbout.age)
-            done()
-          })
+      it('resolves link to an element in array', (done) => {
+        resolve(ipldService, `${mh}/friends/0`, (err, res) => {
+          expect(err).to.not.exist
+          expect(res).to.be.eql(bob)
+          done()
         })
+      })
 
-        it('resolves link to an element in array', (done) => {
-          resolve(ipldService, `${mh}/friends/0`, (err, res) => {
-            expect(err).to.not.exist
-            expect(res).to.be.eql(bob)
-            done()
-          })
-        })
-
-        it('resolves link to property in an element in array', (done) => {
-          resolve(ipldService, `${mh}/friends/0/name`, (err, res) => {
-            expect(err).to.not.exist
-            expect(res).to.be.eql(bob.name)
-            done()
-          })
+      it('resolves link to property in an element in array', (done) => {
+        resolve(ipldService, `${mh}/friends/0/name`, (err, res) => {
+          expect(err).to.not.exist
+          expect(res).to.be.eql(bob.name)
+          done()
         })
       })
     })

--- a/test/ipld-tests.js
+++ b/test/ipld-tests.js
@@ -131,13 +131,19 @@ module.exports = (repo) => {
         const aliceAbout = {
           age: 22
         }
+        const bob = {
+          name: 'Bob'
+        }
         const alice = {
           name: {
             '@link': ipld.multihash(ipld.marshal(aliceName))
           },
           about: {
             '@link': ipld.multihash(ipld.marshal(aliceAbout))
-          }
+          },
+          friends: [{
+            '@link': ipld.multihash(ipld.marshal(bob))
+          }]
         }
         const mh = ipld.multihash(ipld.marshal(alice))
 
@@ -145,14 +151,15 @@ module.exports = (repo) => {
           async.series([
             (cb) => ipldService.add(aliceName, cb),
             (cb) => ipldService.add(aliceAbout, cb),
-            (cb) => ipldService.add(alice, cb)
+            (cb) => ipldService.add(alice, cb),
+            (cb) => ipldService.add(bob, cb)
           ], done)
         })
 
         it('resolves link to string', (done) => {
           resolve(ipldService, `${mh}/name`, (err, res) => {
             expect(err).to.not.exist
-            expect(res).to.be.eql('Alice')
+            expect(res).to.be.eql(alice.name)
             done()
           })
         })
@@ -160,7 +167,7 @@ module.exports = (repo) => {
         it('resolves link to object', (done) => {
           resolve(ipldService, `${mh}/about`, (err, res) => {
             expect(err).to.not.exist
-            expect(res).to.be.eql({age: 22})
+            expect(res).to.be.eql(aliceAbout)
             done()
           })
         })
@@ -168,7 +175,23 @@ module.exports = (repo) => {
         it('resolves link to property in a different object', (done) => {
           resolve(ipldService, `${mh}/about/age`, (err, res) => {
             expect(err).to.not.exist
-            expect(res).to.be.eql(22)
+            expect(res).to.be.eql(aliceAbout.age)
+            done()
+          })
+        })
+
+        it('resolves link to an element in array', (done) => {
+          resolve(ipldService, `${mh}/friends/0`, (err, res) => {
+            expect(err).to.not.exist
+            expect(res).to.be.eql(bob)
+            done()
+          })
+        })
+
+        it('resolves link to property in an element in array', (done) => {
+          resolve(ipldService, `${mh}/friends/0/name`, (err, res) => {
+            expect(err).to.not.exist
+            expect(res).to.be.eql(bob.name)
             done()
           })
         })

--- a/test/ipld-tests.js
+++ b/test/ipld-tests.js
@@ -136,7 +136,7 @@ module.exports = (repo) => {
         }
         const alice = {
           name: {
-            '@link': ipld.multihash(ipld.marshal(aliceName))
+            '@link': ipld.multihash(aliceName)
           },
           about: {
             '@link': ipld.multihash(ipld.marshal(aliceAbout))
@@ -159,7 +159,7 @@ module.exports = (repo) => {
         it('resolves link to string', (done) => {
           resolve(ipldService, `${mh}/name`, (err, res) => {
             expect(err).to.not.exist
-            expect(res).to.be.eql(alice.name)
+            expect(res).to.be.eql(aliceName)
             done()
           })
         })


### PR DESCRIPTION
I created a new block called `across linked objects`,
inside this block there is another block `where links are multihashes`,
since in my view links could also be paths e.g.`{name: {@link: /hash/person/name}}` and I expect `where links are paths` to happen soon (I can just remove it for now)

The tests are not passing:
- [ ] I am not sure how I can point directly to the hash of a string (see line 130 and 153)
- [ ] if `{about: {'@link': 'hash'}}` and I look for `/about`, the link should be resolved, instead of returning `{'@link': 'hash'}`
- [ ] same for `friends/0/bob`

(my reference spec is both the ipld one and my attempt for [ip-paths](https://github.com/nicola/interplanetary-paths))